### PR TITLE
Add different environments

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,6 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=user
+spring.datasource.password=password
 book.system.environment=prod
 spring.jpa.show-sql=false
 spring.jpa.properties.hiberante.format_sql=false

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,2 +1,5 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres-test
+spring.datasource.username=user
+spring.datasource.password=password
 book.system.environment=test
 #-Dspring-boot.run.profiles==test

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres-dev
 spring.datasource.username=user
 spring.datasource.password=password
 spring.jpa.show-sql=true


### PR DESCRIPTION
In a previous commit, I have created
1. application-test.properties
2. application-prod.properties

Each of the *.properties has a different logging level.
Each of the *.properties has a different DB connection to simulate a real life usage.